### PR TITLE
Feature/alternative time

### DIFF
--- a/src/main/java/com/meetcha/meeting/domain/MeetingEntity.java
+++ b/src/main/java/com/meetcha/meeting/domain/MeetingEntity.java
@@ -43,14 +43,18 @@ public class MeetingEntity {
     @Column(name = "confirmed_time")
     private LocalDateTime confirmedTime;
 
+    @Column(name = "meeting_code", nullable = false, unique = true)
+    private String meetingCode;
+
+    @Column(name = "alternative_deadline")
+    private LocalDateTime alternativeDeadline;
+
     @Column(name = "created_by", nullable = false)
     private UUID createdBy;
 
     @Column(name = "project_id", nullable = true)
     private UUID projectId;
 
-    @Column(name = "code", nullable = false, unique = true)
-    private String code;
     // todo 미팅 생성 시 디폴트 값 설정 -> Service에서 직접 UUID 생성 후 채워넣음
 
 

--- a/src/main/java/com/meetcha/meeting/domain/MeetingRepository.java
+++ b/src/main/java/com/meetcha/meeting/domain/MeetingRepository.java
@@ -28,8 +28,15 @@ public interface MeetingRepository extends JpaRepository<MeetingEntity, UUID> {
             @Param("status") MeetingStatus status
     );
 
-
-
+    // 투표 마감 후 가장 많이 투표된 대안 시간을 확정 시 사용
+    @Query("""
+    SELECT m FROM MeetingEntity m
+    WHERE m.alternativeDeadline IS NOT NULL
+      AND m.confirmedTime IS NULL
+      AND m.alternativeDeadline < CURRENT_TIMESTAMP
+      AND m.meetingStatus = 'MATCHING'
+""")
+    List<MeetingEntity> findMeetingsToConfirmFromAlternative();
 
 
     List<MeetingEntity> findByMeetingStatusAndConfirmedTimeBefore(MeetingStatus meetingStatus, LocalDateTime now);

--- a/src/main/java/com/meetcha/meeting/scheduler/MeetingStatusUpdateScheduler.java
+++ b/src/main/java/com/meetcha/meeting/scheduler/MeetingStatusUpdateScheduler.java
@@ -3,13 +3,18 @@ package com.meetcha.meeting.scheduler;
 import com.meetcha.meeting.domain.MeetingEntity;
 import com.meetcha.meeting.domain.MeetingRepository;
 import com.meetcha.meeting.domain.MeetingStatus;
+import com.meetcha.meeting.service.MeetingScheduleSyncService;
+import com.meetcha.meetinglist.domain.AlternativeTimeEntity;
+import com.meetcha.meetinglist.repository.AlternativeTimeRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -18,6 +23,8 @@ public class MeetingStatusUpdateScheduler {
 //매 5분마다 미팅의 현재 상태를 시간 흐름에 따라 자동 전이하는 역할
 //사용자 입력 없이, 시스템이 시간 흐름을 따라 미팅 상태를 관리한다.
     private final MeetingRepository meetingRepository;
+    private final AlternativeTimeRepository alternativeTimeRepository;
+    private final MeetingScheduleSyncService syncService;
 
     // 매 5분마다 실행 -30마다 실행해도 되나
     @Scheduled(fixedRate = 5 * 60 * 1000)
@@ -47,4 +54,27 @@ public class MeetingStatusUpdateScheduler {
         meetingRepository.saveAll(toStart);
         meetingRepository.saveAll(toEnd);
     }
+
+    @Scheduled(cron = "0 */10 * * * *") // 매 10분마다 실행
+    @Transactional
+    public void confirmFromAlternativeTimes() {
+        List<MeetingEntity> targets = meetingRepository.findMeetingsToConfirmFromAlternative();
+
+        for (MeetingEntity meeting : targets) {
+            Optional<AlternativeTimeEntity> confirmed = alternativeTimeRepository
+                    .findTopByMeetingIdOrderByVoteCountDescStartTimeAsc(meeting.getMeetingId());
+
+            if (confirmed.isPresent()) {
+                meeting.setConfirmedTime(confirmed.get().getStartTime());
+                meeting.setMeetingStatus(MeetingStatus.BEFORE);
+                meetingRepository.save(meeting);
+
+                syncService.syncMeetingToCalendars(meeting); // 구글 캘린더 연동
+            } else {
+                meeting.setMeetingStatus(MeetingStatus.MATCH_FAILED);
+                meetingRepository.save(meeting);
+            }
+        }
+    }
+
 }

--- a/src/main/java/com/meetcha/meeting/service/MeetingConfirmationService.java
+++ b/src/main/java/com/meetcha/meeting/service/MeetingConfirmationService.java
@@ -61,6 +61,7 @@ public class MeetingConfirmationService {
                 meeting.setMeetingStatus(MeetingStatus.MATCH_FAILED);
             } else {
                 saveAlternativeTimeCandidates(meetingId, alterTimes);
+                updateAlternativeDeadlineFromCandidates(meeting);
                 meeting.setMeetingStatus(MeetingStatus.MATCHING);
             }
 
@@ -152,6 +153,22 @@ public class MeetingConfirmationService {
             alternativeTimeRepository.save(entity);
         }
     }
+
+    private void updateAlternativeDeadlineFromCandidates(MeetingEntity meeting) {
+        List<AlternativeTimeEntity> candidates = alternativeTimeRepository.findByMeetingId(meeting.getMeetingId());
+
+        if (candidates.isEmpty()) return;
+
+        // 가장 이른 날짜의 전날 23:59
+        LocalDate earliestDate = candidates.stream()
+                .map(a -> a.getStartTime().toLocalDate())
+                .min(LocalDate::compareTo)
+                .orElseThrow();
+
+        LocalDateTime alternativeDeadline = earliestDate.minusDays(1).atTime(23, 59);
+        meeting.setAlternativeDeadline(alternativeDeadline); // MeetingEntity에 필드 존재해야 함
+    }
+
 
 
 }

--- a/src/main/java/com/meetcha/meetinglist/repository/AlternativeTimeRepository.java
+++ b/src/main/java/com/meetcha/meetinglist/repository/AlternativeTimeRepository.java
@@ -2,6 +2,7 @@ package com.meetcha.meetinglist.repository;
 
 import com.meetcha.meetinglist.domain.AlternativeTimeEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,4 +13,16 @@ public interface AlternativeTimeRepository extends JpaRepository<AlternativeTime
     Optional<AlternativeTimeEntity> findByMeetingIdAndStartTime(UUID meetingId, LocalDateTime localDateTime);
 
     List<AlternativeTimeEntity> findByMeetingId(UUID meetingId);
+
+    //투표 수가 가장 많은 대안 시간 중 가장 빠른 시간을 반환
+    @Query("""
+    SELECT a FROM AlternativeTimeEntity a
+    WHERE a.meetingId = :meetingId
+    ORDER BY 
+        (SELECT COUNT(v) FROM AlternativeVoteEntity v WHERE v.alternativeTimeId = a.alternativeTimeId AND v.checked = true) DESC,
+        a.startTime ASC
+""")
+    Optional<AlternativeTimeEntity> findTopByMeetingIdOrderByVoteCountDescStartTimeAsc(UUID meetingId);
+
+
 }


### PR DESCRIPTION
1. MeetingEntity에 alternativeDeadline 필드 추가
2. 대안 시간 생성 후 가장 빠른 후보일 기준 마감 시각 계산
3. 마감 이후 스케줄러가 최다 득표 대안 시간으로 미팅 자동 확정
4. 확정 실패 시 MATCH_FAILED 상태로 전환