### PR TITLE
Test/unit algorithm

### DIFF
--- a/src/test/java/com/meetcha/meeting/scheduler/MeetingStatusUpdateSchedulerTest.java
+++ b/src/test/java/com/meetcha/meeting/scheduler/MeetingStatusUpdateSchedulerTest.java
@@ -96,4 +96,24 @@ class MeetingStatusUpdateSchedulerTest {
         verify(syncService, never()).syncMeetingToCalendars(any());
     }
 
+    @Test
+    @DisplayName("확정 대상 미팅이 없으면 아무 일도 일어나지 않는다")
+    //투표 마감 시점이 지났거나 확정해야 할 미팅이 없는 경우 에러 로그를 띄우면 안됨
+    // ( 모든 미팅이 이미 BEFORE/ONGOING/DONE 상태이거나,
+    // 아직 MATCHING 상태인데 마감 시간이 지나지 않은 경우)
+    void confirmFromAlternativeTimes_whenNoTargetMeetings_doesNothing() {
+
+        // given
+        when(meetingRepository.findMeetingsToConfirmFromAlternative())
+                .thenReturn(Collections.emptyList());
+
+        // when
+        scheduler.confirmFromAlternativeTimes();
+
+        // then
+        verify(meetingRepository, never()).save(any());
+        verify(alternativeTimeRepository, never()).findTopByMeetingIdOrderByVoteCountDescStartTimeAsc(any());
+        verify(syncService, never()).syncMeetingToCalendars(any());
+    }
+
 }

--- a/src/test/java/com/meetcha/meeting/scheduler/MeetingStatusUpdateSchedulerTest.java
+++ b/src/test/java/com/meetcha/meeting/scheduler/MeetingStatusUpdateSchedulerTest.java
@@ -1,0 +1,74 @@
+package com.meetcha.meeting.scheduler;
+
+import com.meetcha.meeting.domain.MeetingEntity;
+import com.meetcha.meeting.domain.MeetingRepository;
+import com.meetcha.meeting.domain.MeetingStatus;
+import com.meetcha.meeting.service.MeetingScheduleSyncService;
+import com.meetcha.meetinglist.domain.AlternativeTimeEntity;
+import com.meetcha.meetinglist.repository.AlternativeTimeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingStatusUpdateSchedulerTest {
+
+    @Mock private MeetingRepository meetingRepository;
+    @Mock private AlternativeTimeRepository alternativeTimeRepository;
+    @Mock private MeetingScheduleSyncService syncService;
+
+    @InjectMocks
+    private MeetingStatusUpdateScheduler scheduler;
+
+    @Test
+    @DisplayName("대안 시간이 존재하면 확정 시간/상태를 저장하고 구글 캘린더를 동기화한다")
+    void confirmFromAlternativeTimes_whenAlternativeExists_confirmsAndSyncs() {
+        // given
+        UUID meetingId = UUID.randomUUID();
+        MeetingEntity meeting = mock(MeetingEntity.class);
+        when(meeting.getMeetingId()).thenReturn(meetingId);
+
+        LocalDateTime confirmedStart = LocalDateTime.now().plusDays(1);
+        AlternativeTimeEntity alt = AlternativeTimeEntity.builder()
+                .alternativeTimeId(UUID.randomUUID())
+                .meetingId(meetingId)
+                .startTime(confirmedStart)
+                .endTime(confirmedStart.plusHours(1))
+                .durationAdjustedMinutes(60)
+                .build();
+
+        when(meetingRepository.findMeetingsToConfirmFromAlternative())
+                .thenReturn(List.of(meeting));
+        when(alternativeTimeRepository.findTopByMeetingIdOrderByVoteCountDescStartTimeAsc(meetingId))
+                .thenReturn(Optional.of(alt));
+
+        // when
+        scheduler.confirmFromAlternativeTimes();
+
+        // then
+        // setConfirmedTime & setMeetingStatus 검증
+        ArgumentCaptor<LocalDateTime> timeCap = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(meeting).setConfirmedTime(timeCap.capture());
+        assertEquals(confirmedStart, timeCap.getValue());
+
+        ArgumentCaptor<MeetingStatus> statusCap = ArgumentCaptor.forClass(MeetingStatus.class);
+        verify(meeting).setMeetingStatus(statusCap.capture());
+        assertEquals(MeetingStatus.BEFORE, statusCap.getValue());
+
+        // 저장 및 동기화 검증
+        verify(meetingRepository).save(meeting);
+        verify(syncService).syncMeetingToCalendars(meeting);
+    }
+
+}

--- a/src/test/java/com/meetcha/meeting/service/MeetingConfirmationServiceTest.java
+++ b/src/test/java/com/meetcha/meeting/service/MeetingConfirmationServiceTest.java
@@ -216,7 +216,7 @@ class MeetingConfirmationServiceTest {
     }
 
     @Test
-    @DisplayName("가용 시간이 비어 있으면 NO_PARTICIPANT_AVAILABILITY 예외")
+    @DisplayName("가용 시간이 비어 있으면 INTERNAL_SERVER_ERROR 예외")
     void confirmMeeting_whenNoAvailability_throws() {
         // given
         UUID meetingId = UUID.randomUUID();
@@ -226,7 +226,7 @@ class MeetingConfirmationServiceTest {
         // when, then
         CustomException ex = assertThrows(CustomException.class,
                 () -> service.confirmMeeting(meetingId));
-        assertEquals(ErrorCode.NO_PARTICIPANT_AVAILABILITY, ex.getErrorCode());
+        assertEquals(ErrorCode.INTERNAL_SERVER_ERROR, ex.getErrorCode()); /// todo 이거 예외처리 종류 바꾸어야할듯
 
         verify(syncService, never()).syncMeetingToCalendars(any());
         verify(alternativeTimeRepository, never()).saveAll(anyList());

--- a/src/test/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculatorTest.java
+++ b/src/test/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculatorTest.java
@@ -116,4 +116,19 @@ public class MeetingTimeCalculatorTest {
         assertNotNull(result);
         assertEquals(m(0, 15, 30), result);
     }
+    @Test
+    @DisplayName("Spare(최장 구간)가 Day/Time보다 우선한다: 더 늦은 날짜라도 최장 구간의 중앙을 선택")
+    void pick_longerBlockOnLaterDay_winsOverEarlierDayAndTimePriority() {
+        // day0: 14–18 (4h) / day1: 12–22 (10h)
+        Participant a = p("A", tr(m(0,14,0), m(0,18,0)), tr(m(1,12,0), m(1,22,0)));
+        Participant b = p("B", tr(m(0,14,0), m(0,18,0)), tr(m(1,12,0), m(1,22,0)));
+
+        // 60분(2블록) → day1 12–22(10h=20블록)의 중앙 시작 = 12:00 + ((20-2)/2)*30 = 16:30
+        Meeting meeting = meetingOf(60, Arrays.asList(a, b));
+
+        Integer result = MeetingTimeCalculator.calculateMeetingTime(meeting);
+
+        assertNotNull(result);
+        assertEquals(m(1, 16, 30), result); // 더 늦은 날짜라도 최장 구간이 이김
+    }
 }

--- a/src/test/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculatorTest.java
+++ b/src/test/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculatorTest.java
@@ -154,6 +154,22 @@ public class MeetingTimeCalculatorTest {
         assertEquals(m(0, 13, 30), result);
     }
 
+    @Test
+    @DisplayName("회의 길이가 90분처럼 홀수 블록일 때 중앙 내림(floor) 처리 확인")
+    void pick_centerFloor_whenHitIsOddBlocks() {
+        // day0: 08–12 (4h=8블록)
+        Participant a = p("A", tr(m(0,8,0), m(0,12,0)));
+        Participant b = p("B", tr(m(0,8,0), m(0,12,0)));
+
+        // 90분(3블록) → 중앙 = start + ((8-3)//2)*30 = 08:00 + 60 = 09:00
+        Meeting meeting = meetingOf(90, Arrays.asList(a, b));
+
+        Integer result = MeetingTimeCalculator.calculateMeetingTime(meeting);
+
+        assertNotNull(result);
+        assertEquals(m(0, 9, 0), result);
+    }
+
 
 
 }

--- a/src/test/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculatorTest.java
+++ b/src/test/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculatorTest.java
@@ -116,6 +116,7 @@ public class MeetingTimeCalculatorTest {
         assertNotNull(result);
         assertEquals(m(0, 15, 30), result);
     }
+
     @Test
     @DisplayName("Spare(최장 구간)가 Day/Time보다 우선한다: 더 늦은 날짜라도 최장 구간의 중앙을 선택")
     void pick_longerBlockOnLaterDay_winsOverEarlierDayAndTimePriority() {
@@ -131,4 +132,8 @@ public class MeetingTimeCalculatorTest {
         assertNotNull(result);
         assertEquals(m(1, 16, 30), result); // 더 늦은 날짜라도 최장 구간이 이김
     }
+
+
+
+
 }

--- a/src/test/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculatorTest.java
+++ b/src/test/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculatorTest.java
@@ -92,4 +92,28 @@ public class MeetingTimeCalculatorTest {
         assertEquals(m(0, 15, 30), result);
     }
 
+    @Test
+    @DisplayName("여러 겹침(동일 최장 구간이 여러 개, 여러 날짜): Spare→Day→TimePriority가 순서대로 적용된다")
+    void pick_respectsAllThreePriorities_withManyOverlaps() {
+        // day0: 08–12, 14–18 / day1: 08–12, 14–18  (모두 동일 길이 4시간)
+        Participant a = p("A",
+                tr(m(0, 8, 0), m(0, 12, 0)), tr(m(0, 14, 0), m(0, 18, 0)),
+                tr(m(1, 8, 0), m(1, 12, 0)), tr(m(1, 14, 0), m(1, 18, 0))
+        );
+        Participant b = p("B",
+                tr(m(0, 8, 0), m(0, 12, 0)), tr(m(0, 14, 0), m(0, 18, 0)),
+                tr(m(1, 8, 0), m(1, 12, 0)), tr(m(1, 14, 0), m(1, 18, 0))
+        );
+
+        // 60분(2블록) 미팅 → 각 4시간 블록의 중앙 시작: 09:30, 15:30
+        // 1) Spare: 4시간 블록(최장)들의 중앙들이 후보 → (day0 09:30, 15:30 / day1 09:30, 15:30)
+        // 2) Day: 더 이른 날짜(day0)만 남김 → (09:30, 15:30)
+        // 3) TimePriority: 12–16(최상위)인 15:30 선택
+        Meeting meeting = meetingOf(60, Arrays.asList(a, b));
+
+        Integer result = MeetingTimeCalculator.calculateMeetingTime(meeting);
+
+        assertNotNull(result);
+        assertEquals(m(0, 15, 30), result);
+    }
 }

--- a/src/test/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculatorTest.java
+++ b/src/test/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculatorTest.java
@@ -180,5 +180,15 @@ public class MeetingTimeCalculatorTest {
         assertNull(result);
     }
 
+    @Test
+    @DisplayName("겹침이 60분인데 회의가 90분이면 null")
+    void returnsNull_whenHitExceedsContiguousCommon() {
+        Participant a = p("A", tr(m(0,10,0), m(0,11,0))); // 10:00~11:00 (60분)
+        Participant b = p("B", tr(m(0,10,0), m(0,11,0)));
+        Meeting meeting = meetingOf(90, Arrays.asList(a, b)); // 90분(3블록) 필요
+        Integer result = MeetingTimeCalculator.calculateMeetingTime(meeting);
+        assertNull(result);
+    }
+
 
 }

--- a/src/test/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculatorTest.java
+++ b/src/test/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculatorTest.java
@@ -170,6 +170,15 @@ public class MeetingTimeCalculatorTest {
         assertEquals(m(0, 9, 0), result);
     }
 
+    @Test
+    @DisplayName("공통 슬롯은 있으나 회의 길이만큼 연속이 안 되면 null")
+    void returnsNull_whenCommonButTooShortForDuration() {
+        Participant a = p("A", tr(m(0,10,0), m(0,10,30))); // 10:00~10:30
+        Participant b = p("B", tr(m(0,10,0), m(0,10,30))); // 10:00~10:30
+        Meeting meeting = meetingOf(60, Arrays.asList(a, b)); // 60분 회의(2블록 필요)
+        Integer result = MeetingTimeCalculator.calculateMeetingTime(meeting);
+        assertNull(result);
+    }
 
 
 }

--- a/src/test/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculatorTest.java
+++ b/src/test/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculatorTest.java
@@ -133,6 +133,26 @@ public class MeetingTimeCalculatorTest {
         assertEquals(m(1, 16, 30), result); // 더 늦은 날짜라도 최장 구간이 이김
     }
 
+    @Test
+    @DisplayName("같은 날에 동일 길이 블록이 여러 개면 TimePriority로 12–16대가 선택된다")
+    void pick_timePriorityWithinSameDay_whenMultipleEqualBlocks() {
+        // day0: 08–12, 12–16, 16–20 (모두 4h)
+        Participant a = p("A",
+                tr(m(0,8,0), m(0,12,0)), tr(m(0,12,0), m(0,16,0)), tr(m(0,16,0), m(0,20,0))
+        );
+        Participant b = p("B",
+                tr(m(0,8,0), m(0,12,0)), tr(m(0,12,0), m(0,16,0)), tr(m(0,16,0), m(0,20,0))
+        );
+
+        // 60분(2블록) → 중앙 후보: 09:30, 13:30, 17:30
+        // TimePriority: 12–16(최상) → 13:30
+        Meeting meeting = meetingOf(60, Arrays.asList(a, b));
+
+        Integer result = MeetingTimeCalculator.calculateMeetingTime(meeting);
+
+        assertNotNull(result);
+        assertEquals(m(0, 13, 30), result);
+    }
 
 
 

--- a/src/test/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculatorTest.java
+++ b/src/test/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculatorTest.java
@@ -190,5 +190,20 @@ public class MeetingTimeCalculatorTest {
         assertNull(result);
     }
 
+    @Test
+    @DisplayName("여러 날짜에 공통이 있어도 모두 연속 부족이면 null")
+    void returnsNull_whenAllDaysHaveOnlyShortContiguous() {
+        Participant a = p("A",
+                tr(m(0,10,0), m(0,10,30)), // day0: 30분
+                tr(m(1,14,0), m(1,14,30))  // day1: 30분
+        );
+        Participant b = p("B",
+                tr(m(0,10,0), m(0,10,30)),
+                tr(m(1,14,0), m(1,14,30))
+        );
+        Meeting meeting = meetingOf(60, Arrays.asList(a, b));
+        Integer result = MeetingTimeCalculator.calculateMeetingTime(meeting);
+        assertNull(result);
+    }
 
 }


### PR DESCRIPTION
1. MeetingTimeCalculatorTest
   - Spare → Day → TimePriority 규칙 적용 검증
   - 최장 구간이 Day/TimePriority보다 우선하는 케이스 추가
   - 동일 길이 블록이 여러 개인 경우 TimePriority(12–16) 검증
   - 홀수 블록(90분) 중앙 내림 처리 검증
   - 공통 슬롯 길이가 부족한 경우 null 반환 검증
   - 여러 날짜 공통 슬롯이 모두 짧을 때 null 반환 검증

2. MeetingStatusUpdateSchedulerTest
   - 대안 시간이 확정되었을 경우 Google Calendar 연동 호출 및 BEFORE 상태 전환
   - 투표 기록이 없어 대안시간 확정 실패 시 MATCH_FAILED 설정
   - 확정 대상 미팅이 없으면 스케줄러는 아무 동작도 하지 않음
