### PR TITLE
[Refactor] exception 처리 도메인별로 변경

### DIFF
--- a/src/main/java/com/meetcha/global/dto/ApiResponse.java
+++ b/src/main/java/com/meetcha/global/dto/ApiResponse.java
@@ -1,6 +1,7 @@
 package com.meetcha.global.dto;
 
 import com.meetcha.global.exception.ErrorCode;
+import com.meetcha.global.exception.ErrorCodeBase;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
@@ -24,11 +25,11 @@ public class ApiResponse<T> {
         return new ApiResponse<>(code, message, null);
     }
 
-    public static <T> ApiResponse<T> error(ErrorCode errorCode) {
+    public static <T> ApiResponse<T> error(ErrorCodeBase errorCode) {
         return new ApiResponse<>(errorCode.getCode(), errorCode.getMessage(), null);
     }
 
-    public static <T> ApiResponse<T> error(ErrorCode errorCode, T data) {
+    public static <T> ApiResponse<T> error(ErrorCodeBase errorCode, T data) {
         return new ApiResponse<>(errorCode.getCode(), errorCode.getMessage(), data);
     }
 }

--- a/src/main/java/com/meetcha/global/exception/CustomException.java
+++ b/src/main/java/com/meetcha/global/exception/CustomException.java
@@ -1,28 +1,24 @@
 package com.meetcha.global.exception;
 
+import lombok.Getter;
+
 import java.util.Map;
 
+@Getter
 public class CustomException extends RuntimeException {
-    private final ErrorCode errorCode;
+    private final ErrorCodeBase errorCode;
     private final Map<String, String> fieldErrors;
 
-    public CustomException(ErrorCode errorCode) {
+    public CustomException(ErrorCodeBase errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
         this.fieldErrors = null;
     }
 
-    public CustomException(ErrorCode errorCode, Map<String, String> fieldErrors) {
+    public CustomException(ErrorCodeBase errorCode, Map<String, String> fieldErrors) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
         this.fieldErrors = fieldErrors;
     }
 
-    public ErrorCode getErrorCode() {
-        return errorCode;
-    }
-
-    public Map<String, String> getFieldErrors() {
-        return fieldErrors;
-    }
 }

--- a/src/main/java/com/meetcha/global/exception/ErrorCode.java
+++ b/src/main/java/com/meetcha/global/exception/ErrorCode.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum ErrorCode {
+public enum ErrorCode implements ErrorCodeBase {
 
     //400 Bad Request
     INVALID_GOOGLE_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 구글 인가 코드입니다."),

--- a/src/main/java/com/meetcha/global/exception/ErrorCodeBase.java
+++ b/src/main/java/com/meetcha/global/exception/ErrorCodeBase.java
@@ -1,0 +1,9 @@
+package com.meetcha.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCodeBase {
+    HttpStatus getHttpStatus();
+    String getMessage();
+    int getCode();
+}

--- a/src/main/java/com/meetcha/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/meetcha/global/exception/GlobalExceptionHandler.java
@@ -12,7 +12,7 @@ public class GlobalExceptionHandler {
     //모든 커스텀 예외 처리
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponse<Object>> handleCustomException(CustomException e) {
-        ErrorCode errorCode = e.getErrorCode();
+        ErrorCodeBase errorCode = e.getErrorCode();
 
         // fieldErrors가 있으면 data에 같이
         if (e.getFieldErrors() != null) {

--- a/src/main/java/com/meetcha/user/exception/UserErrorCode.java
+++ b/src/main/java/com/meetcha/user/exception/UserErrorCode.java
@@ -1,0 +1,23 @@
+package com.meetcha.user.exception;
+
+import com.meetcha.global.exception.ErrorCodeBase;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum UserErrorCode implements ErrorCodeBase {
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "미팅을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    UserErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public int getCode() {
+        return httpStatus.value();
+    }
+}

--- a/src/main/java/com/meetcha/user/service/UserProfileService.java
+++ b/src/main/java/com/meetcha/user/service/UserProfileService.java
@@ -2,12 +2,15 @@ package com.meetcha.user.service;
 
 import com.meetcha.auth.domain.UserEntity;
 import com.meetcha.auth.domain.UserRepository;
+import com.meetcha.global.exception.CustomException;
 import com.meetcha.user.dto.MyPageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
+
+import static com.meetcha.user.exception.UserErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -18,7 +21,7 @@ public class UserProfileService {
 
     public MyPageResponse getMyPage(UUID userId) {
         UserEntity user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+                .orElseThrow(()->new CustomException(USER_NOT_FOUND));
         return new MyPageResponse(
                 user.getName(),
                 user.getProfileImgSrc()


### PR DESCRIPTION
## refactor: 에러 처리 구조 개선 및 도메인별 분리

### 개요 (Overview)

기존에 `global` 패키지에 중앙 집중되어 있던 `ErrorCode`를 각 도메인별로 분리하여 관리하도록 구조를 개선했습니다. 이를 통해 앞으로 프로젝트 규모가 커지더라도 에러 코드를 더 체계적으로 관리하고 확장할 수 있습니다.

-----

### 📝 변경 내용 (Changes)

  - **`ErrorCodeBase` 인터페이스 신규 생성**

      - 모든 도메인별 에러 Enum이 공통으로 구현할 인터페이스(`getHttpStatus`, `getMessage` 등)를 정의했습니다.

  - **도메인별 에러 Enum 생성**

      - `global.exception.ErrorCode`는 이제 공통 에러(예: `INTERNAL_SERVER_ERROR`)만 담당합니다.
      - 각 도메인 패키지 하위에 `ErrorCodeBase`를 구현하는 새로운 에러 Enum을 추가했습니다. (예: `MeetingErrorCode`, `UserErrorCode`)

  - **`CustomException` 및 `ApiResponse` 수정**

      - `CustomException`이 특정 `ErrorCode`가 아닌 `ErrorCodeBase` 인터페이스를 받도록 수정하여, 어떤 도메인의 에러든 처리할 수 있도록 변경했습니다.
      - `ApiResponse`의 `error()` 팩토리 메서드 또한 `ErrorCodeBase`를 받도록 수정했습니다.

  - **`GlobalExceptionHandler` 수정**

      - `handleCustomException` 메서드가 `ErrorCodeBase`를 통해 에러를 처리하도록 수정하여 기존 로직을 그대로 유지하면서 확장성을 확보했습니다.

-----

### 🤔 왜 변경했나요? (Reason for Change)

  - **유지보수성**: 하나의 `ErrorCode` Enum 파일이 수백 줄로 비대해지는 것을 방지하고, 각 도메인에 맞는 에러를 쉽게 찾고 추가할 수 있습니다.
  - **응집도**: 에러 코드가 관련된 비즈니스 로직과 같은 패키지 내에 위치하여 코드의 응집도를 높입니다.
  - **확장성**: 새로운 도메인이 추가될 때 `global` 패키지를 건드리지 않고도 독립적으로 에러를 정의하고 확장할 수 있습니다.

-----

### ⚠️ 참고 사항 (Notes)

앞으로 새로운 에러 코드를 추가할 때는 각 도메인 패키지 하위에 `ErrorCodeBase`를 구현한 Enum을 생성하여 사용해주세요.

**예시)**

```java
// src/main/java/com/meetcha/example/exception/ExampleErrorCode.java

public enum ExampleErrorCode implements ErrorCodeBase {
    EXAMPLE_NOT_FOUND(HttpStatus.NOT_FOUND, "예시를 찾을 수 없습니다.");
    // ...
}
```