### PR TITLE
Logout

### DIFF
--- a/src/main/java/com/meetcha/auth/controller/UserController.java
+++ b/src/main/java/com/meetcha/auth/controller/UserController.java
@@ -1,6 +1,8 @@
 package com.meetcha.auth.controller;
 
 import com.meetcha.auth.dto.*;
+import com.meetcha.auth.service.LogoutService;
+import com.meetcha.global.annotation.AuthUser;
 import com.meetcha.global.dto.ApiResponse;
 import com.meetcha.auth.service.LoginService;
 import com.meetcha.auth.service.RefreshTokenService;
@@ -10,12 +12,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @RestController
 @RequestMapping("/oauth")
 @RequiredArgsConstructor
 public class UserController {
     private final LoginService loginService;
     private final RefreshTokenService refreshTokenService;
+    private final LogoutService logoutService;
+
 
     @PostMapping("/google")
     public TokenResponseDto googleLogin(@RequestBody LoginRequestDto request) {
@@ -26,11 +32,15 @@ public class UserController {
     public TokenResponseDto refresh(@RequestBody RefreshTokenRequestDto request) {
         return refreshTokenService.reissueAccessToken(request.getRefreshToken());
     }
-
     @PostMapping("/test")
     public TestLoginResponse testLogin(
             @RequestBody TestLoginRequest testLoginRequest) {
         return loginService.testLogin(testLoginRequest);
     }
 
+    @PostMapping("/logout")
+    public ResponseEntity<LogoutResponseDto> logout(@AuthUser UUID userId) {
+        LogoutResponseDto response = logoutService.logout(userId);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/meetcha/auth/dto/LogoutResponseDto.java
+++ b/src/main/java/com/meetcha/auth/dto/LogoutResponseDto.java
@@ -1,0 +1,10 @@
+package com.meetcha.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LogoutResponseDto {
+    private String message;
+}

--- a/src/main/java/com/meetcha/auth/service/LogoutService.java
+++ b/src/main/java/com/meetcha/auth/service/LogoutService.java
@@ -1,0 +1,41 @@
+package com.meetcha.auth.service;
+
+import com.meetcha.auth.domain.RefreshTokenRepository;
+import com.meetcha.auth.dto.LogoutResponseDto;
+import com.meetcha.global.exception.CustomException;
+import com.meetcha.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LogoutService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public LogoutResponseDto logout(UUID userId) {
+        log.info("[Logout] Starting logout process for userId: {}", userId);
+
+        // RefreshToken 삭제
+        refreshTokenRepository.findByUserId(userId)
+                .ifPresentOrElse(
+                        refreshToken -> {
+                            refreshTokenRepository.delete(refreshToken);
+                            log.info("[Logout] RefreshToken deleted for userId: {}", userId);
+                        },
+                        () -> {
+                            log.warn("[Logout] No RefreshToken found for userId: {}", userId);
+                            throw new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+                        }
+                );
+
+        log.info("[Logout] Logout completed successfully for userId: {}", userId);
+        return new LogoutResponseDto("로그아웃 성공");
+    }
+}

--- a/src/main/java/com/meetcha/global/exception/ErrorCode.java
+++ b/src/main/java/com/meetcha/global/exception/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode implements ErrorCodeBase {
     REFLECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "회고를 찾을 수 없습니다."),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "리소스를 찾을 수 없습니다."),
     PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "프로젝트를 찾을 수 없습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "리프레쉬 토큰을 찾을 수 없습니다."),
 
     //409 Conflict
     ALREADY_VOTED_ALTERNATIVE(HttpStatus.BAD_REQUEST, "이미 대안시간 투표를 제출하였습니다."),

--- a/src/main/java/com/meetcha/meeting/dto/MeetingDeleteResponse.java
+++ b/src/main/java/com/meetcha/meeting/dto/MeetingDeleteResponse.java
@@ -1,0 +1,17 @@
+package com.meetcha.meeting.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MeetingDeleteResponse {
+    private UUID meetingId;
+    private String message;
+}


### PR DESCRIPTION
사용자 로그아웃 기능을 구현
 로그아웃 시 해당 사용자의 RefreshToken을 데이터베이스에서 삭제하여 토큰 재발급을 불가능하게 한다.

  - POST /oauth/logout 엔드포인트 추가
    - JWT 토큰 기반 인증 (@AuthUser로 userId 추출)
    - RefreshToken 존재 여부 확인 및 삭제
    - @Transactional 적용으로 안전한 트랜잭션 처리
  - LogoutService 구현
    - RefreshToken 조회 및 삭제 로직
    - RefreshToken이 없는 경우 예외 처리
    - 로그 기록 추가 (로그아웃 시작, RefreshToken 삭제, 완료)
  - LogoutResponseDto 추가
    - 로그아웃 성공 메시지 반환용 DTO
  - ErrorCode.REFRESH_TOKEN_NOT_FOUND 추가
    - 404 Not Found
    - "리프레쉬 토큰을 찾을 수 없습니다."

