### PR TITLE
Fix/meeting matching logic

### DIFF
--- a/src/main/java/com/meetcha/meeting/service/MeetingConfirmationService.java
+++ b/src/main/java/com/meetcha/meeting/service/MeetingConfirmationService.java
@@ -40,6 +40,10 @@ public class MeetingConfirmationService {
         MeetingEntity meeting = meetingRepository.findByIdForUpdate(meetingId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEETING_NOT_FOUND));
 
+        if (meeting.getConfirmedTime() != null) {
+            return;
+        }
+
         log.info("confirmMeeting 접근 완료");
         // 1. 참여자 가용 시간 조회
         List<ParticipantAvailability> allAvailability = availabilityRepository.findByMeetingId(meetingId);

--- a/src/main/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculator.java
+++ b/src/main/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculator.java
@@ -22,14 +22,18 @@ public class MeetingTimeCalculator {
                 (currentCount, totalCount) -> currentCount == totalCount
         );
 
-        if (timeSequence.isEmpty()) return null;
+        Map<Integer, Integer> filtered = timeSequence.entrySet().stream()
+                .filter(entry -> entry.getValue() >= hit)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        if (filtered.isEmpty()) return null;
 
         // 2. 우선순위 1: 여유 시간이 많은 시간대
-        List<Integer> timeList = timeSequence.keySet().stream()
-                .sorted(Comparator.comparingInt(timeSequence::get))
+        List<Integer> timeList = filtered.keySet().stream()
+                .sorted(Comparator.comparingInt(filtered::get))
                 .collect(Collectors.toList());
 
-        List<Integer> spareCandidates = SortUtils.sortBySpare(timeList,timeSequence, hit, PER);
+        List<Integer> spareCandidates = SortUtils.sortBySpare(timeList,filtered, hit, PER);
         if (spareCandidates == null || spareCandidates.isEmpty()) return null;
 
         // 3. 우선순위 2: 가장 빠른 날짜

--- a/src/main/java/com/meetcha/user/service/UserScheduleService.java
+++ b/src/main/java/com/meetcha/user/service/UserScheduleService.java
@@ -14,9 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -52,48 +50,32 @@ public class UserScheduleService {
                 .toList();
 
         Map<String, List<ScheduleResponse>> dailyGroups =
-                valid.stream()
-                        .collect(Collectors.groupingBy(s ->
-                                s.getTitle() + "|" + s.getStartAt().toLocalTime()
-                        ));
+                valid.stream().collect(Collectors.groupingBy(s ->
+                        s.getTitle() + "|" + s.getStartAt().toLocalTime()
+                ));
 
         Map<String, List<ScheduleResponse>> weeklyGroups =
-                valid.stream()
-                        .collect(Collectors.groupingBy(s ->
-                                s.getTitle()
-                                        + "|" + s.getStartAt().getDayOfWeek()
-                                        + "|" + s.getStartAt().toLocalTime()
-                        ));
+                valid.stream().collect(Collectors.groupingBy(s ->
+                        s.getTitle() + "|" + s.getStartAt().getDayOfWeek() + "|" + s.getStartAt().toLocalTime()
+                ));
 
         Map<String, List<ScheduleResponse>> monthlyGroups =
-                valid.stream()
-                        .collect(Collectors.groupingBy(s ->
-                                s.getTitle()
-                                        + "|" + s.getStartAt().getDayOfMonth()
-                                        + "|" + s.getStartAt().toLocalTime()
-                        ));
+                valid.stream().collect(Collectors.groupingBy(s ->
+                        s.getTitle() + "|" + s.getStartAt().getDayOfMonth() + "|" + s.getStartAt().toLocalTime()
+                ));
+
+        Set<String> seen = new HashSet<>();
 
         return valid.stream()
                 .map(s -> {
                     String dailyKey = s.getTitle() + "|" + s.getStartAt().toLocalTime();
-                    String weeklyKey = s.getTitle()
-                            + "|" + s.getStartAt().getDayOfWeek()
-                            + "|" + s.getStartAt().toLocalTime();
-                    String monthlyKey = s.getTitle()
-                            + "|" + s.getStartAt().getDayOfMonth()
-                            + "|" + s.getStartAt().toLocalTime();
+                    String weeklyKey = s.getTitle() + "|" + s.getStartAt().getDayOfWeek() + "|" + s.getStartAt().toLocalTime();
+                    String monthlyKey = s.getTitle() + "|" + s.getStartAt().getDayOfMonth() + "|" + s.getStartAt().toLocalTime();
 
-                    if (hasConsecutiveDays(dailyGroups.getOrDefault(dailyKey, List.of()))) {
-                        return ScheduleResponse.builder()
-                                .eventId(s.getEventId())
-                                .title(s.getTitle())
-                                .startAt(s.getStartAt())
-                                .endAt(s.getEndAt())
-                                .recurrence("DAILY")
-                                .build();
-                    }
-
+                    // MONTHLY
                     if (monthlyGroups.getOrDefault(monthlyKey, List.of()).size() >= 2) {
+                        if (!seen.add("M:" + monthlyKey)) return null;
+
                         return ScheduleResponse.builder()
                                 .eventId(s.getEventId())
                                 .title(s.getTitle())
@@ -103,7 +85,10 @@ public class UserScheduleService {
                                 .build();
                     }
 
+                    // WEEKLY
                     if (weeklyGroups.getOrDefault(weeklyKey, List.of()).size() >= 2) {
+                        if (!seen.add("W:" + weeklyKey)) return null;
+
                         return ScheduleResponse.builder()
                                 .eventId(s.getEventId())
                                 .title(s.getTitle())
@@ -113,8 +98,22 @@ public class UserScheduleService {
                                 .build();
                     }
 
+                    // DAILY
+                    if (hasConsecutiveDays(dailyGroups.getOrDefault(dailyKey, List.of()))) {
+                        if (!seen.add("D:" + dailyKey)) return null;
+
+                        return ScheduleResponse.builder()
+                                .eventId(s.getEventId())
+                                .title(s.getTitle())
+                                .startAt(s.getStartAt())
+                                .endAt(s.getEndAt())
+                                .recurrence("DAILY")
+                                .build();
+                    }
+
                     return s;
                 })
+                .filter(Objects::nonNull)
                 .toList();
     }
 


### PR DESCRIPTION
문제 상황
1. 미팅 확정 로직 오류
- 일부 시간만 겹쳐도 BEFORE(성공) 상태로 변경되는 문제 발생
- 회의 duration(연속 시간) 검증 없이 확정 처리됨
2. 일정 조회 중복 문제 (/user/schedule)
- 동일한 일정이 여러 개 반환되는 현상 발생
- 특히 DAILY / WEEKLY / MONTHLY 반복 일정에서 중복

원인
1. 미팅 확정 로직
- 연속 시간(duration) 검증 없이 일부 시간 겹침만으로 성공 처리됨
- 확정된 미팅이 중복 실행될 수 있는 구조
2. 일정 중복
- Google Calendar에서 가져온 이벤트를 그룹화만 하고
- 중복 제거 없이 그대로 반환
- 동일 recurrence 그룹 내 이벤트가 여러 개 내려감

수정 내용
- duration(연속 시간) 만족하는 경우만 확정되도록 필터링 추가
- confirmedTime != null 시 조기 return 처리 → 이미 확정된 미팅 재처리 방지