### PR TITLE
fix: 미팅 확정 시 참여자 일부 입력 상태에서 BEFORE로 전이되는 버그 수정

### DIFF
--- a/src/main/java/com/meetcha/meeting/service/MeetingConfirmationService.java
+++ b/src/main/java/com/meetcha/meeting/service/MeetingConfirmationService.java
@@ -40,13 +40,19 @@ public class MeetingConfirmationService {
         MeetingEntity meeting = meetingRepository.findByIdForUpdate(meetingId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEETING_NOT_FOUND));
 
-        if (meeting.getConfirmedTime() != null) {
-            return;
-        }
-
         log.info("confirmMeeting 접근 완료");
         // 1. 참여자 가용 시간 조회
         List<ParticipantAvailability> allAvailability = availabilityRepository.findByMeetingId(meetingId);
+
+        Set<UUID> submittedParticipantIds = new HashSet<>();
+        for (ParticipantAvailability a : allAvailability) {
+            submittedParticipantIds.add(a.getParticipantId());
+        }
+
+        if (submittedParticipantIds.size() < 2) {
+            return;
+        }
+
         if (allAvailability.isEmpty()) {
             // 참여자가 아무도 가용시간을 안 넣고 마감된 경우 → 매칭 실패 처리
             meeting.setMeetingStatus(MeetingStatus.MATCH_FAILED);


### PR DESCRIPTION
## 문제
- 참여자 전체가 availability를 입력하기 전에 confirmMeeting이 실행되면서
  일부 참여자 기준으로 미팅이 BEFORE 상태로 확정되는 문제 발생

## 해결
- availability 기준 고유 참여자 수를 계산하여
  2명 미만일 경우 confirmMeeting 실행을 차단하도록 수정

## 효과
- 미완료 입력 상태에서의 잘못된 BEFORE 전이 방지
- 간헐적으로 발생하던 미팅 확정 오류 해결