### PR TITLE
Fix/meeting matching logic

### DIFF
--- a/src/main/java/com/meetcha/meeting/service/MeetingConfirmationService.java
+++ b/src/main/java/com/meetcha/meeting/service/MeetingConfirmationService.java
@@ -59,6 +59,8 @@ public class MeetingConfirmationService {
 
         // 변환 후 계산
         Meeting converted = MeetingConverter.toAlgorithmMeeting(meeting, allAvailability);
+
+        int requiredMinutes = (int) Math.ceil(meeting.getDurationMinutes() * 2.0 / 3);
         Integer bestStartMinutes = MeetingTimeCalculator.calculateMeetingTime(converted);
         log.info("변환 후 계산 완료");
 
@@ -96,6 +98,23 @@ public class MeetingConfirmationService {
             meetingRepository.save(meeting);
             log.info("meetingRepository.save 완료");
 
+            return;
+        }
+
+        int actualMinutes = MeetingTimeCalculator.getMaxContinuousMinutes(converted);
+
+        if (actualMinutes < requiredMinutes) {
+            List<AlternativeTimeEntity> alterTimes =
+                    AlternativeTimeCalculator.getAlternativeTimes(converted, meetingId);
+
+            if (alterTimes.isEmpty()) {
+                meeting.setMeetingStatus(MeetingStatus.MATCH_FAILED);
+            } else {
+                saveAlternativeTimeCandidates(meetingId, alterTimes);
+                meeting.setMeetingStatus(MeetingStatus.MATCHING);
+            }
+
+            meetingRepository.save(meeting);
             return;
         }
 

--- a/src/main/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculator.java
+++ b/src/main/java/com/meetcha/meeting/service/algorithm/MeetingTimeCalculator.java
@@ -12,6 +12,18 @@ public class MeetingTimeCalculator {
 
     private static final int PER = 30; // 시간 단위: 30분
 
+    public static int getMaxContinuousMinutes(Meeting meeting) {
+        Map<Integer, Integer> seq = getTimeSequence(
+                meeting,
+                PER,
+                (currentCount, totalCount) -> currentCount == totalCount
+        );
+
+        return seq.values().stream()
+                .max(Integer::compareTo)
+                .orElse(0) * PER;
+    }
+
     public static Integer calculateMeetingTime(Meeting meeting) {
         int hit = meeting.getDuration() / PER;
 


### PR DESCRIPTION
## 변경 사항
미팅 확정 로직에서 단순 bestTime 존재 여부로 BEFORE 상태로 전이되던 문제 수정
회의 시간의 2/3 이상을 전원이 공통으로 만족하는 경우에만 확정되도록 보완
공통 가능한 최대 연속 시간(getMaxContinuousMinutes) 기반 검증 로직 추가

##  문제 상황
기존에는 calculateMeetingTime() 결과가 존재하면 무조건 BEFORE로 확정됨
이로 인해 실제 요구사항(전원 공통 시간 ≥ 2/3)을 만족하지 않아도 미팅이 확정되는 문제 발생
일부 케이스에서 대안 시간 단계로 넘어가야 하는 미팅이 BEFORE로 잘못 전이됨

## 해결 방법
getMaxContinuousMinutes()를 통해 전원 공통 가능한 최대 연속 시간 계산
requiredMinutes = duration * 2 / 3 기준 추가
아래 조건을 만족할 때만 BEFORE로 확정되도록 수정
actualMinutes >= requiredMinutes
조건 미충족 시:
대안 시간 존재 → MATCHING
대안 없음 → MATCH_FAILED